### PR TITLE
fix: correct auth route paths, JWT payload, and login error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ backend/certs/*.key
 # ── IDE / OS ──────────────────────────────────────────────────────────────
 .vscode/
 .claude/
+doc/codeguide/
 .idea/
 .DS_Store
 *.swp

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -8,8 +8,8 @@ const router = Router();
 // POST /api/auth/login
 // GET  /api/auth/me
 
-router.get('/api/auth/me', auth, getMeController);
-router.post('/api/auth/signup', signupController);
-router.post('/api/auth/login', loginController);
+router.get('/me', auth, getMeController);
+router.post('/signup', signupController);
+router.post('/login', loginController);
 
 export default router;

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -15,9 +15,9 @@ export async function hashPassword(password: string): Promise<string> {
   return await bcrypt.hash(password, saltRounds);
 }
 
-export function generateToken(userId: number, email: string): string {
+export function generateToken(id: number, email: string, username: string): string {
   return jwt.sign(
-    { userId, email },
+    { id, email, username },
     jwtSecret,
     { expiresIn: '1m' }
   );
@@ -56,12 +56,12 @@ export async function signup(email: string, username: string, password: string):
 	},
   });
 
-  return generateToken(user.id, user.email);
+  return generateToken(user.id, user.email, user.username);
 }
 
 export async function login(email: string, password: string): Promise<string> {
   if (!email || !password) {
-    throw new Error('Email or password missing');
+    throw new Error('Email and password are required');
   }
   const user = await prisma.user.findUnique({
 	  where: { email },
@@ -77,5 +77,5 @@ export async function login(email: string, password: string): Promise<string> {
     data: { isOnline: true, updatedAt: new Date() },
   });
 
-  return generateToken(user.id, user.email);
+  return generateToken(user.id, user.email, user.username);
 }

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -68,15 +68,15 @@
 
 ### Backend Auth API — [Backend: tzizi]
 
-- [ ] Install bcrypt and jsonwebtoken: `npm install bcrypt jsonwebtoken`
-- [ ] Install types: `npm install -D @types/bcrypt @types/jsonwebtoken`
-- [ ] Create `middleware/auth.ts` — JWT token verification middleware
-- [ ] Create `routes/auth.ts`:
-  - [ ] `POST /api/auth/signup` — validate input, hash password, create user, return JWT
-  - [ ] `POST /api/auth/login` — verify email + password, return JWT
-  - [ ] `GET /api/auth/me` — return current user from JWT (protected route)
-- [ ] Input validation: email format, password min length (8 chars), username min length (3 chars)
-- [ ] Error responses: 400 (bad input), 401 (wrong credentials), 409 (email/username taken)
+- [x] Install bcrypt and jsonwebtoken: `npm install bcrypt jsonwebtoken`
+- [x] Install types: `npm install -D @types/bcrypt @types/jsonwebtoken`
+- [x] Create `middleware/auth.ts` — JWT token verification middleware
+- [x] Create `routes/auth.ts`:
+  - [x] `POST /api/auth/signup` — validate input, hash password, create user, return JWT
+  - [x] `POST /api/auth/login` — verify email + password, return JWT
+  - [x] `GET /api/auth/me` — return current user from JWT (protected route)
+- [x] Input validation: email format, password min length (8 chars), username min length (3 chars)
+- [x] Error responses: 400 (bad input), 401 (wrong credentials), 409 (email/username taken)
 
 ### Frontend Auth Pages — [Frontend: mgodawat]
 


### PR DESCRIPTION
## Fix auth API critical bugs

Three bugs introduced during the auth API implementation:

- **Route double-prefix**: Routes were defined as `/api/auth/signup` inside a
  router already mounted at `/api/auth`, making all endpoints unreachable (404)
- **JWT payload mismatch**: Token was signed with `userId` but `getMeController`
  read `id`; `username` was missing from the payload entirely
- **Login error message mismatch**: Service threw a different string than what
  the controller caught, causing missing-credentials to return 500 instead of 400
 
