### PR TITLE
feat(user): allow authenticated users to update their own displayName

### DIFF
--- a/backend/src/controllers/users.controller.ts
+++ b/backend/src/controllers/users.controller.ts
@@ -5,6 +5,8 @@
 
 import { Request, Response } from 'express';
 import { getUserById } from '../services/users.service';
+import { AuthRequest } from '../middleware/auth';
+import { updateUserById } from '../services/users.service';
 
 export const getUser = async (req: Request, res: Response): Promise<void> => {
   const id = Number(req.params.id);
@@ -27,5 +29,38 @@ export const getUser = async (req: Request, res: Response): Promise<void> => {
   } catch (error) {
     console.error('Error fetching user:', error);
     res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+//UpdateProfile
+export const updateMyProfile = async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+    const { displayName } = req.body;
+
+    // Validation métier : displayName 1-50 caractères
+    if (
+      typeof displayName !== 'string' ||
+      displayName.length < 1 ||
+      displayName.length > 50
+    ) {
+      return res.status(400).json({ error: 'displayName must be 1-50 characters' });
+    }
+
+    // Appel au service pour mettre à jour
+    const updatedUser = await updateUserById(userId, { displayName });
+
+    return res.status(200).json(updatedUser);
+  } catch (error: any) {
+    console.error('Error updating user profile:', error);
+
+    // Prisma error si user non trouvé
+    if (error.code === 'P2025') {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    return res.status(500).json({ error: 'Internal server error' });
   }
 };

--- a/backend/src/routes/users.routes.ts
+++ b/backend/src/routes/users.routes.ts
@@ -1,14 +1,15 @@
 import { Router } from "express";
-import { getUser } from '../controllers/users.controller';
-
+import { getUser, updateMyProfile } from '../controllers/users.controller';
+import { auth } from '../middleware/auth';
 
 const router = Router();
 
 // GET  /api/users/:id
-
 router.get('/:id', getUser);
 
 // PUT  /api/users/me
+router.put('/me', auth, updateMyProfile);
+
 // POST /api/users/me/avatar
 
 export default router;

--- a/backend/src/services/users.service.ts
+++ b/backend/src/services/users.service.ts
@@ -3,6 +3,11 @@
 
 import prisma from '../lib/prisma';   // ← importe l'instance partagée
 
+type UpdateUserData = {
+  displayName?: string; // facultatif si tu veux pouvoir mettre à jour partiellement
+};
+
+//Get User profile
 export const getUserById = async (id: number) => {
   const user = await prisma.user.findUnique({
     where: { id },
@@ -17,4 +22,28 @@ export const getUserById = async (id: number) => {
   });
 
   return user;
+};
+
+//MAJ User profile
+export const updateUserById = async (
+  userId: number,
+  data: UpdateUserData
+) => {
+  // Ne mettre à jour que les champs autorisés
+  const allowedFields: UpdateUserData = {
+    displayName: data.displayName,
+  };
+
+  const updatedUser = await prisma.user.update({
+    where: { id: userId },
+    data: allowedFields,
+    select: {
+      id: true,
+      username: true,
+      displayName: true,
+      avatarUrl: true,
+    },
+  });
+
+  return updatedUser;
 };


### PR DESCRIPTION
# ✨ Feature: Update authenticated user profile (displayName)

Closes #30

## 📌 Description

This PR introduces a new protected endpoint allowing an authenticated user to update their own profile information — specifically their **displayName**.

**Endpoint added:**

```
PUT /api/users/me
```

This route is protected by JWT authentication and requires a valid:

```
Authorization: Bearer <token>
```

---

## 🔐 Authentication

Uses existing JWT authentication middleware.

Requires valid Bearer token.

Handles:

- Missing token → `401 Unauthorized`
- Invalid token → `401 Unauthorized`
- Expired token → `401 Unauthorized`

---

## 🧠 Business Logic

Only the authenticated user can update their own profile.

**Allowed field:**

- `displayName`

**Validation rules:**

- Must be a string
- Must be between **1 and 50 characters**

Invalid input returns:

```
400 Bad Request
```

If the user does not exist:

```
404 Not Found
```

Successful update returns:

```
200 OK
```

With the updated user object:

```json
{
  "id": number,
  "username": string,
  "displayName": string,
  "avatarUrl": string | null
}
```

---

## 🛠 Implementation Details

- **Controller:** `users.controller.ts`
- **Service logic:** `users.service.ts`
- **Route:** `users.routes.ts`
- Protected via existing auth middleware
- Prisma used for DB update
- Only allowed fields are explicitly whitelisted in service layer

---

## ✅ Tests Performed

Manual tests using `curl`:

- ✔ Valid update
- ✔ Empty displayName
- ✔ Too long displayName
- ✔ Missing token
- ✔ Invalid token
- ✔ Expired token
- ✔ Bearer format enforcement

All scenarios returned expected HTTP status codes.

---

## 🔒 Security Notes

- Endpoint strictly scoped to authenticated user (`/me`)
- No arbitrary user ID modification allowed
- JWT validation fully enforced
- Only whitelisted fields can be updated