### PR TITLE
feat: Implement friend request feature

### DIFF
--- a/backend/src/controllers/friends.controller.ts
+++ b/backend/src/controllers/friends.controller.ts
@@ -1,2 +1,38 @@
-// Friends controller — handles HTTP request/response for friend operations
-// Calls friends.service.ts for business logic
+import { Response } from "express";
+import { AuthRequest } from "../middleware/auth";
+import { createFriendRequest } from "../services/friends.service";
+
+export async function sendFriendRequest(req: AuthRequest, res: Response): Promise<void> {
+  try {
+    const requesterId: number = req.user.id;
+
+    //Check Param Runtime
+    const userIdParam = req.params.userId;
+
+    if (!userIdParam || typeof userIdParam !== "string") {
+      res.status(400).json({ error: "Invalid user ID" });
+      return;
+    }
+
+    //Extract ID
+    const addresseeId = parseInt(userIdParam, 10);  // ← corrigé
+
+    if (isNaN(addresseeId)) {
+      res.status(400).json({ error: "Invalid user ID" });
+      return;
+    }
+
+    //Call service
+    const friendRequest = await createFriendRequest(requesterId, addresseeId);  // ← corrigé
+
+    res.status(201).json(friendRequest);
+
+  } catch (error: any) {
+    if (error.status) {
+      res.status(error.status).json({ error: error.message });
+      return;
+    }
+    console.error("sendFriendRequest error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+}

--- a/backend/src/routes/friends.routes.ts
+++ b/backend/src/routes/friends.routes.ts
@@ -1,9 +1,13 @@
 import { Router } from "express";
+import { sendFriendRequest } from "../controllers/friends.controller";
+import { auth } from "../middleware/auth";
 
 const router = Router();
 
 // GET    /api/friends
 // GET    /api/friends/requests
+router.post("/request/:userId", auth, sendFriendRequest);
+
 // POST   /api/friends/request/:userId
 // POST   /api/friends/accept/:requestId
 // DELETE /api/friends/:friendId

--- a/backend/src/services/friends.service.ts
+++ b/backend/src/services/friends.service.ts
@@ -1,2 +1,59 @@
 // Friends service — business logic for friend operations
 // Send request, accept, reject, remove, list friends
+
+import prisma from '../lib/prisma';
+
+//Send Friend Request
+export async function createFriendRequest(requesterId: number, addresseeId: number) {
+
+  //Self-FriendRequest Check
+  if (requesterId === addresseeId) {
+    throw { status: 400, message: "You cannot send a friend request to yourself" };
+  }
+
+  //Check User
+  const addressee = await prisma.user.findUnique({
+    where: { id: addresseeId },
+  });
+
+  if (!addressee) {
+    throw { status: 400, message: "User not found" };
+  }
+
+  //Check if FriendRequest available (A→B ou B→A, pending/accepted)
+  const existing = await prisma.friend.findFirst({
+    where: {
+      OR: [
+        { requesterId: requesterId, addresseeId: addresseeId },
+        { requesterId: addresseeId, addresseeId: requesterId },
+      ],
+      status: { in: ["PENDING", "ACCEPTED"] },
+    },
+  });
+
+  if (existing) {
+    if (existing.status === "ACCEPTED") {
+      throw { status: 409, message: "You are already friends with this user" };
+    }
+    throw { status: 409, message: "A friend request already exists between you and this user" };
+  }
+
+  //Create FriendRequest
+  const friendRequest = await prisma.friend.create({
+    data: {
+      requester: { connect: { id: requesterId } },
+      addressee: { connect: { id: addresseeId } },
+      status: "PENDING",
+    },
+    include: {
+      requester: {
+        select: { id: true, username: true },
+      },
+      addressee: {
+        select: { id: true, username: true },
+      },
+    },
+  });
+
+  return friendRequest;
+}


### PR DESCRIPTION
## Description

Allow authenticated users to send friend requests to other users. This creates a pending relationship that the recipient can accept or reject later.

**Route:** `POST /api/friends/request/:userId` (protected with JWT)

## Files Modified

- `backend/src/routes/friends.routes.ts` — Route definition, JWT middleware
- `backend/src/controllers/friends.controller.ts` — HTTP request/response handling
- `backend/src/services/friends.service.ts` — Business logic & validation

## Validations

1. Cannot send a friend request to yourself → 400
2. Target user must exist in database → 400
3. Invalid user ID in URL → 400
4. No token / invalid token → 401
5. Request already pending → 409
6. Already friends → 409

## API

**Request:**
POST /api/friends/request/:userId
Headers: Authorization: Bearer <jwt-token>

**Success Response (201):**

{
  "id": 1,
  "requesterId": 1,
  "addresseeId": 2,
  "status": "PENDING",
  "createdAt": "2026-02-22T02:21:10.329Z",
  "requester": { "id": 1, "username": "user1" },
  "addressee": { "id": 2, "username": "user2" }
}

## Tests Performed

- [x] Create friend request → 201
- [x] Self-request → 400
- [x] Duplicate request → 409
- [x] Non-existent user → 400

## Acceptance Criteria

- [x] Route POST /api/friends/request/:userId protected with JWT
- [x] Creates Friend record with status PENDING
- [x] requesterId extracted from JWT (req.user.id)
- [x] addresseeId extracted from URL params
- [x] Returns 400 if sending request to yourself
- [x] Returns 400 if target user doesn't exist
- [x] Returns 409 if request already exists (pending or accepted)
- [x] Returns created friend request object
- [x] Includes requester and addressee user info in response