### PR TITLE
feat(accept-friend-request): implement accept friend request endpoint

### DIFF
--- a/backend/src/controllers/friends.controller.ts
+++ b/backend/src/controllers/friends.controller.ts
@@ -5,6 +5,7 @@ import { Response } from "express";
 import { AuthRequest } from "../middleware/auth";
 import {
   createFriendRequest,
+  acceptFriendRequest,
 } from "../services/friends.service";
 
 //      SEND FRIEND REQUEST
@@ -40,6 +41,39 @@ export async function sendFriendRequest(req: AuthRequest, res: Response): Promis
       return;
     }
     console.error("sendFriendRequest error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+}
+
+//    ACCEPT FRIEND REQUEST
+
+export async function acceptFriendRequestController(req: AuthRequest, res: Response): Promise<void> {
+  try {
+    const currentUserId: number = req.user.id;
+    const requestIdParam = req.params.requestId;
+
+    if (!requestIdParam) {
+      res.status(400).json({ error: "Invalid request ID" });
+      return;
+    }
+
+    const requestId = parseInt(requestIdParam as string, 10);
+
+    if (isNaN(requestId)) {
+      res.status(400).json({ error: "Invalid request ID" });
+      return;
+    }
+
+    const updatedRequest = await acceptFriendRequest(requestId, currentUserId);
+
+    res.status(200).json(updatedRequest);
+
+  } catch (error: any) {
+    if (error.status) {
+      res.status(error.status).json({ error: error.message });
+      return;
+    }
+    console.error("acceptFriendRequest error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 }

--- a/backend/src/routes/friends.routes.ts
+++ b/backend/src/routes/friends.routes.ts
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { auth } from "../middleware/auth";
 import {
-  sendFriendRequest,
+    acceptFriendRequestController,
+    sendFriendRequest,
 } from "../controllers/friends.controller";
 
 const router = Router();
@@ -13,6 +14,7 @@ const router = Router();
 router.post("/request/:userId", auth, sendFriendRequest);
 
 // POST   /api/friends/accept/:requestId
+router.post("/accept/:requestId", auth, acceptFriendRequestController);
 // DELETE /api/friends/:friendId
 
 export default router;


### PR DESCRIPTION
## Feature: Accept Friend Request Closes #34 

### Overview
This feature allows a user to **accept a pending friend request**. When a friend request is accepted, the status changes from `"PENDING"` to `"ACCEPTED"` and the users become friends. Any attempt to accept a request that is already accepted or does not exist is properly handled with an error response.

### Implementation Details
- **Route:** `POST /api/friends/accept/:requestId` (protected with JWT)
- **User:** The authenticated user (`receiver`) accepts a friend request sent by another user (`sender`).
- **FriendRequest Status:** Changes from `"PENDING"` → `"ACCEPTED"`.

### Validations
- Returns `400 Bad Request` if the request is already accepted.
- Returns `404 Not Found` if the request ID does not exist.
- Returns `400 Bad Request` if the request ID is invalid.

### Response
- Returns the updated `FriendRequest` object with:
  - `id`
  - `requesterId` & `addresseeId`
  - `status`
  - `createdAt`
  - Nested `requester` and `addressee` user info

### Files Edited
- `backend/src/routes/friends.routes.ts`
- `backend/src/controllers/friends.controller.ts`
- `backend/src/services/friends.service.ts`

### Notes
- Fully tested with `curl` to simulate sending and accepting friend requests.
- Handles all edge cases: double accept, invalid ID, and non-existent request.