### PR TITLE
feat(Move-Validation) Implement Move-Validation function

### DIFF
--- a/backend/src/services/games.service.ts
+++ b/backend/src/services/games.service.ts
@@ -1,2 +1,92 @@
 // Games service — business logic for game operations
 // Create game, validate moves, win detection, draw detection
+
+import type { GameState, GameStatus, Player } from '../types/game';
+
+// ───────────────── CONST ERROR ─────────────────
+
+export const MOVE_ERRORS = {
+  NOT_ACTIVE:           'Game is not active',
+  WAITING_FOR_OPPONENT: 'Waiting for opponent',
+  GAME_FINISHED:        'Game already finished',
+  GAME_CANCELLED:       'Game has been cancelled',
+  GAME_ABANDONED:       'Game has been abandoned',
+  INVALID_CELL:         'Invalid cell index',
+  CELL_OCCUPIED:        'Cell already occupied',
+  NOT_IN_GAME:          'You are not in this game',
+  NOT_YOUR_TURN:        'Not your turn',
+} as const;
+
+// ───────────────── Types ─────────────────
+
+export interface MoveValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+// ───────────────── Interns Helpers ─────────────────
+
+//We need to return null, not a throw
+const safeGetPlayerSymbol = (
+  game: GameState,
+  userId: number,
+): Player | null => {
+  if (userId === game.player1Id) return game.player1Symbol;
+  if (userId === game.player2Id) return game.player2Symbol;
+  return null;
+};
+
+//Check cell index
+const isCellIndexValid = (cellIndex: number, boardSize: number): boolean =>
+  Number.isInteger(cellIndex) &&
+  cellIndex >= 0 &&
+  cellIndex < boardSize * boardSize;
+
+type NonPlayableStatus = Exclude<GameStatus, 'IN_PROGRESS'>;
+
+const statusErrorMap: Record<NonPlayableStatus, string> = {
+  WAITING:   MOVE_ERRORS.WAITING_FOR_OPPONENT,
+  FINISHED:  MOVE_ERRORS.GAME_FINISHED,
+  DRAW:      MOVE_ERRORS.GAME_FINISHED,
+  CANCELLED: MOVE_ERRORS.GAME_CANCELLED,
+  ABANDONED: MOVE_ERRORS.GAME_ABANDONED,
+};
+
+// ───────────────── Main Functions ─────────────────
+
+//  VALIDATE MOVE
+export const validateMove = (
+  gameState: GameState,
+  cellIndex: number,
+  userId: number,
+): MoveValidationResult => {
+
+  //game still in progress ?
+  if (gameState.status !== 'IN_PROGRESS') {
+    const error = statusErrorMap[gameState.status] ?? MOVE_ERRORS.NOT_ACTIVE;
+    return { valid: false, error };
+  }
+
+  //Cell index valid ?
+  if (!isCellIndexValid(cellIndex, gameState.boardSize)) {
+    return { valid: false, error: MOVE_ERRORS.INVALID_CELL };
+  }
+
+  //Cell value === null ?
+  if (gameState.boardState[cellIndex] !== null) {
+    return { valid: false, error: MOVE_ERRORS.CELL_OCCUPIED };
+  }
+
+  //Player is in the game ?
+  const symbol = safeGetPlayerSymbol(gameState, userId);
+  if (symbol === null) {
+    return { valid: false, error: MOVE_ERRORS.NOT_IN_GAME };
+  }
+
+  //Player turn ?
+  if (symbol !== gameState.currentTurn) {
+    return { valid: false, error: MOVE_ERRORS.NOT_YOUR_TURN };
+  }
+
+  return { valid: true };
+};


### PR DESCRIPTION
## 🎯 Move Validation — `validateMove()` pure function Closes #86

### Summary

Implements server-side move validation for tic-tac-toe games.
This is the core "referee" logic that enforces game rules before
any move is applied to the board.

### Files changed

| File | Action | Description |
|---|---|---|
| `src/services/game.service.ts` | **Created** | `validateMove()` function + helpers |
| `src/test/game.service.test.ts` | **Created** | 24 test cases covering all paths |

### What it does

`validateMove(gameState, cellIndex, userId)` → `{ valid: boolean, error?: string }`

A **pure function** (no side effects, no DB access, no mutations) that runs
5 sequential checks before allowing a move:

| # | Check | Error message |
|---|---|---|
| 1 | Game status is `IN_PROGRESS` | `Waiting for opponent` / `Game already finished` / `Game has been cancelled` / `Game has been abandoned` |
| 2 | Cell index is valid (`0` to `boardSize² - 1`) | `Invalid cell index` |
| 3 | Cell is empty (`null`) | `Cell already occupied` |
| 4 | Player belongs to the game | `You are not in this game` |
| 5 | It's the player's turn | `Not your turn` |

Returns `{ valid: true }` only if **all 5 checks pass**.

### Design decisions

- **Result object over thrown errors** — a rejected move is a normal business
  case, not an exception. The caller decides how to handle it (400 response,
  WebSocket message, log, etc.).

- **Exhaustive status mapping** — `Record<NonPlayableStatus, string>` ensures
  that adding a new `GameStatus` in the future will cause a compile-time error
  until the corresponding error message is added. No silent bugs.

- **Format checks before business logic** — cell index is validated before
  checking player identity, following the principle of rejecting obviously
  malformed input first (same pattern as JSON schema → business rules).

- **Dynamic board size support** — cell index validation uses `boardSize`
  from `GameState` instead of hardcoded `0-8`, making it ready for 4×4 or
  5×5 boards without code changes.

- **`safeGetPlayerSymbol` over `getPlayerSymbol`** — the existing helper in
  `game.ts` throws on unknown userId. The service needs a `null` return to
  produce a validation result instead of crashing.

### Test coverage

24 tests — 0 mocks — runs via `npx tsx`:

```bash
npx tsx src/test/game.service.test.ts