### PR TITLE
feat(Win-Detection) Implement Win-Detection function

### DIFF
--- a/backend/src/services/games.service.ts
+++ b/backend/src/services/games.service.ts
@@ -1,7 +1,12 @@
 // Games service — business logic for game operations
 // Create game, validate moves, win detection, draw detection
 
-import type { GameState, GameStatus, Player } from '../types/game';
+import type { 
+  GameState,
+  GameStatus,
+  Player,
+  Board,
+  } from '../types/game';
 
 // ───────────────── CONST ERROR ─────────────────
 
@@ -54,14 +59,15 @@ const statusErrorMap: Record<NonPlayableStatus, string> = {
 
 // ───────────────── Main Functions ─────────────────
 
-//  VALIDATE MOVE
+//        VALIDATE MOVE
+
 export const validateMove = (
   gameState: GameState,
   cellIndex: number,
   userId: number,
 ): MoveValidationResult => {
 
-  //game still in progress ?
+  //Game still in progress ?
   if (gameState.status !== 'IN_PROGRESS') {
     const error = statusErrorMap[gameState.status] ?? MOVE_ERRORS.NOT_ACTIVE;
     return { valid: false, error };
@@ -89,4 +95,37 @@ export const validateMove = (
   }
 
   return { valid: true };
+};
+
+//        CHECK WIN
+
+const WINNING_LINES = [
+  [0, 1, 2], // Up
+  [3, 4, 5], // Mid
+  [6, 7, 8], // Bot
+  [0, 3, 6], // Left
+  [1, 4, 7], // Mid
+  [2, 5, 8], // Right
+  [0, 4, 8], // Diagonale up
+  [2, 4, 6], // Diagonale down
+] as const;
+
+type WinResult = {
+  winner: 'X' | 'O';
+  line: readonly [number, number, number];
+} | null;
+
+export const checkWinnerWithLine = (board: Board, boardSize: number = 3): WinResult => {
+  if (boardSize !== 3) throw new Error('Only 3x3 boards supported');
+  for (const line of WINNING_LINES) {
+    const [a, b, c] = line;
+    if (
+      board[a] !== null &&
+      board[a] === board[b] &&
+      board[a] === board[c]
+    ) {
+      return { winner: board[a], line };
+    }
+  }
+  return null;
 };


### PR DESCRIPTION
## ✨ Add `checkWinnerWithLine` utility for 3x3 board Closes #87

### 📌 Description

This PR introduces a new utility function `checkWinnerWithLine` that determines whether a player has won on a 3x3 board and returns both the winner and the winning line.

Unlike a simple winner check, this implementation also returns the exact winning combination, which can be used for UI highlighting or animations.

### 🧠 Implementation Details

- Defines all possible winning combinations in a constant `WINNING_LINES`
- Supports **3x3 boards only** (throws an error otherwise)
- Iterates through each winning line
- Checks whether:
  - The first cell is not `null`
  - All three positions in the line contain the same value
- Returns an object containing:
  - `winner`: `'X' | 'O'`
  - `line`: the winning cell indexes as a readonly tuple
- Returns `null` if no winner is found

### 🚨 Limitations

- Currently supports only 3x3 boards.
- Throws an error if another board size is provided.

### 🎯 Purpose

This improves separation of concerns by:
- Isolating winner detection logic
- Simplifying UI handling (e.g., highlighting winning cells)
- Providing a strongly typed and predictable result