### PR TITLE
feat(Draw-GameOver-Detection) Implement Draw-GameOver-Detection function

### DIFF
--- a/backend/src/services/games.service.ts
+++ b/backend/src/services/games.service.ts
@@ -129,3 +129,30 @@ export const checkWinnerWithLine = (board: Board, boardSize: number = 3): WinRes
   }
   return null;
 };
+
+//        CHECK DRAW
+
+export const checkDraw = (board: Board): boolean => {
+  return board.every(cell => cell !== null);
+};
+
+//        CHECK GAME OVER
+
+export type GameOverResult =
+  | { gameOver: true;  winner: Player; isDraw: false; line: readonly [number, number, number] }
+  | { gameOver: true;  winner: null;   isDraw: true;  line: null }
+  | { gameOver: false; winner: null;   isDraw: false; line: null };
+
+export const checkGameOver = (board: Board, boardSize: number = 3): GameOverResult => {
+  const winResult = checkWinnerWithLine(board, boardSize);
+
+  if (winResult) {
+    return { gameOver: true, winner: winResult.winner, isDraw: false, line: winResult.line };
+  }
+
+  if (checkDraw(board)) {
+    return { gameOver: true, winner: null, isDraw: true, line: null };
+  }
+
+  return { gameOver: false, winner: null, isDraw: false, line: null };
+};


### PR DESCRIPTION
# ✨ Add `checkDraw` and `checkGameOver` Game Logic Utilities Closes #88

## 📌 Overview

This PR introduces two utility functions to centralize and simplify end-game detection logic:

- `checkDraw`
- `checkGameOver`

These utilities provide a clean, reusable, and type-safe way to determine whether the game has ended, whether there is a winner, or if the game resulted in a draw.

---

## 🧠 What’s Included

### ✅ `checkDraw(board: Board): boolean`

Determines whether the board is completely filled.

**Behavior:**
- Returns `true` if all cells are non-null.
- Returns `false` otherwise.

This keeps draw detection isolated, reusable, and easy to test.

---

### ✅ `checkGameOver(board: Board, boardSize: number = 3): GameOverResult`

Centralized function to determine the current game state.

**Logic flow:**
1. Checks for a winner using `checkWinnerWithLine`.
2. If a winner exists → returns `gameOver: true` with:
   - `winner`
   - `line` (winning combination)
   - `isDraw: false`
3. If no winner but the board is full → returns a draw result.
4. Otherwise → returns a non-terminal game state.

---

## 🔒 Strong Typing with `GameOverResult`

```ts
export type GameOverResult =
  | { gameOver: true;  winner: Player; isDraw: false; line: readonly [number, number, number] }
  | { gameOver: true;  winner: null;   isDraw: true;  line: null }
  | { gameOver: false; winner: null;   isDraw: false; line: null };