### PR TITLE
feat: game page container ui issue #62 / [Phase 3] Game Page Container — Issue #62

### DIFF
--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -90,7 +90,7 @@ export default function Game() {
         </Button>
       </div>
       {/* Scoreboard / Player vs Player */}
-      <div className="inline-block rounded-lg bg-pong-surface px-12 py-2 shadow-sm">
+      <div className="rounded-lg bg-pong-surface px-12 py-2 shadow-sm">
         <div className="flex items-center gap-8 text-pong-text/80">
           {/* Player 1 */}
           <div className="flex flex-col items-center px-3">


### PR DESCRIPTION
## Summary

Implements the Game page container for Phase 3.

- Renders the `GameBoard` component on `/game/:id` with a centered layout.
- Adds a `TurnIndicator` above the board showing whose turn it is.
- Uses local React state to manage the mock board:
  - `Array(9).fill(null)` at start
  - alternates between `X` and `O` on each click
  - logs cell clicks to the console for debugging
- Adds placeholder game controls under the board:
  - **New Game** button (disabled for now)
  - **Quit Game** button (disabled for now)
- Adds a simple scoreboard / player info block under the controls:
  - Player 1: `You (X)`
  - Player 2: `Opponent (O)`
  - Ties counter
  - Styling matches the board (same rounded card look and background)

This is purely mock UI state and will be replaced by real game data in Phase 4.

## How to test

1. Log in.
2. Go to `/game/:id` (e.g. via the "Play" / lobby flow).
3. Click on any cell:
   - the symbol in the cell alternates between X and O on each turn
   - the turn indicator updates accordingly
   - inspect the browser console to see a log for each click
4. Check that:
   - the board is centered
   - the turn indicator is directly above the board
   - the New / Quit buttons are visible but disabled
   - the scoreboard shows “You (X)”, “Opponent (O)” and “Ties”.

Closes #62.