### PR TITLE
feature: Real-Time Move Events Closes #146

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -6540,6 +6540,8 @@
     },
     "node_modules/socket.io-client": {
       "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/backend/src/socket/handlers/game.handlers.ts
+++ b/backend/src/socket/handlers/game.handlers.ts
@@ -1,0 +1,115 @@
+import type { Server, Socket } from "socket.io";
+import { makeMoveInDb, checkGameOver } from "../../services/games.service";
+import { getSocketUser, getGameRoomName, assertGameId } from "../helpers";
+import type { Board } from "../../types/game";
+
+export function registerGameHandlers(io: Server, socket: Socket) {
+
+  socket.on("make_move", async (payload: unknown) => {
+    const rawGameId    = (payload as any)?.gameId;
+    const rawCellIndex = (payload as any)?.cellIndex;
+    const cellIndex    = typeof rawCellIndex === "number" ? rawCellIndex : null;
+    let gameId: number | null = null;
+
+    try {
+      const user = getSocketUser(socket);
+
+      // Check gameId
+      gameId = assertGameId(rawGameId);
+
+      // Check cellIndex
+      if (
+        typeof rawCellIndex !== "number" ||
+        !Number.isInteger(rawCellIndex) ||
+        rawCellIndex < 0 ||
+        rawCellIndex > 8
+      ) {
+        socket.emit("move_error", {
+          error: "Invalid cell index",
+          cellIndex: rawCellIndex ?? null,
+        });
+        return;
+      }
+
+      // Execute Move (atomic transaction in service)
+      const updatedGame = await makeMoveInDb(gameId, rawCellIndex, user.id);
+
+      // Check Player Symbol
+      const playerSymbol = updatedGame.player1Id === user.id
+        ? updatedGame.player1Symbol
+        : updatedGame.player2Symbol;
+
+      // Won line for Frontend
+      const gameOverResult = checkGameOver(
+        updatedGame.boardState as Board,
+        updatedGame.boardSize,
+      );
+
+      // Build game_update payload
+      const gameUpdate: Record<string, unknown> = {
+        gameId:        updatedGame.id,
+        board:         updatedGame.boardState,
+        currentTurn:   updatedGame.currentTurn,
+        status:        updatedGame.status,
+        winner:        updatedGame.winner  ?? null,
+        winnerId:      updatedGame.winnerId ?? null,
+        player1:       updatedGame.player1,
+        player2:       updatedGame.player2,
+        player1Symbol: updatedGame.player1Symbol,
+        player2Symbol: updatedGame.player2Symbol,
+        lastMove: {
+          player:    playerSymbol,
+          userId:    user.id,
+          cellIndex: rawCellIndex,
+          timestamp: new Date().toISOString(),
+        },
+      };
+
+      if (gameOverResult.line) {
+        gameUpdate.winningLine = gameOverResult.line;
+      }
+
+      // Room Broadcast (2 players receives it)
+      const roomName = getGameRoomName(gameId);
+      io.to(roomName).emit("game_update", gameUpdate);
+
+      console.log(
+        `[Game ${gameId}] ${user.username} (${playerSymbol}) → cell ${rawCellIndex}`,
+      );
+
+      // If GameOver Send game_over
+      if (updatedGame.status === "FINISHED" || updatedGame.status === "DRAW") {
+        const gameOver: Record<string, unknown> = {
+          gameId:   updatedGame.id,
+          status:   updatedGame.status,
+          winner:   updatedGame.winner  ?? null,
+          winnerId: updatedGame.winnerId ?? null,
+          board:    updatedGame.boardState,
+        };
+
+        if (gameOverResult.line) {
+          gameOver.winningLine = gameOverResult.line;
+        }
+
+        io.to(roomName).emit("game_over", gameOver);
+
+        const outcome = updatedGame.status === "DRAW"
+          ? "Draw"
+          : `Winner: ${updatedGame.winner?.username ?? updatedGame.winnerId}`;
+
+        console.log(`[Game ${gameId}] Game over — ${outcome}`);
+      }
+
+    } catch (error: unknown) {
+      const rawMessage = error instanceof Error ? error.message : "Failed to make move";
+      const errorMessage = rawMessage.replace(/^Invalid move:\s*/i, "");
+
+      console.warn(`[Game ${gameId ?? "?"}] Move rejected: ${errorMessage}`);
+
+      socket.emit("move_error", {
+        error: errorMessage,
+        cellIndex,
+      });
+    }
+  });
+}

--- a/backend/src/socket/handlers/gameRoom.handlers.ts
+++ b/backend/src/socket/handlers/gameRoom.handlers.ts
@@ -1,15 +1,10 @@
 import type { Server, Socket } from "socket.io";
 import prisma from "../../lib/prisma";
 import { gameRoomService } from "../services/gameRoom.service";
+import { getSocketUser, getGameRoomName, assertGameId } from "../helpers";
 
 type JoinGameRoomPayload = { gameId?: unknown };
 type LeaveGameRoomPayload = { gameId?: unknown };
-
-type SocketUser = {
-  id: number;
-  username: string;
-  avatarUrl?: string;
-};
 
 const gamePlayersSelect = {
   player1: {
@@ -19,31 +14,6 @@ const gamePlayersSelect = {
     select: { id: true, username: true, avatarUrl: true },
   },
 } as const;
-
-function assertGameId(value: unknown): number {
-  if (!Number.isInteger(value) || Number(value) <= 0) {
-    throw new Error("Invalid gameId");
-  }
-  return Number(value);
-}
-
-function roomNameForGame(gameId: number): string {
-  return `game-${gameId}`;
-}
-
-function getSocketUser(socket: Socket): SocketUser {
-  const user = socket.data.user as Partial<SocketUser> | undefined;
-
-  if (!user || typeof user.id !== "number" || typeof user.username !== "string") {
-    throw new Error("Unauthorized");
-  }
-
-  return {
-    id: user.id,
-    username: user.username,
-    avatarUrl: user.avatarUrl,
-  };
-}
 
 function buildJoinedPayload(game: {
   id: number;
@@ -107,7 +77,7 @@ export function registerGameRoomHandlers(_io: Server, socket: Socket) {
         return;
       }
 
-      const roomName = roomNameForGame(gameId);
+      const roomName = getGameRoomName(gameId);
       await socket.join(roomName);
 
       gameRoomService.addPlayerToRoom(gameId, {
@@ -146,7 +116,7 @@ export function registerGameRoomHandlers(_io: Server, socket: Socket) {
     try {
       const user = getSocketUser(socket);
       const gameId = assertGameId(payload?.gameId);
-      const roomName = roomNameForGame(gameId);
+      const roomName = getGameRoomName(gameId);
 
       await socket.leave(roomName);
       gameRoomService.removePlayerFromRoom(gameId, user.id);
@@ -161,7 +131,6 @@ export function registerGameRoomHandlers(_io: Server, socket: Socket) {
       socket.emit("error", { message });
     }
   });
-
 }
 
 export function handleGameRoomDisconnect(_io: Server, socket: Socket) {
@@ -170,7 +139,7 @@ export function handleGameRoomDisconnect(_io: Server, socket: Socket) {
     const removedEntries = gameRoomService.removePlayerFromAllRooms(user.id);
 
     for (const { gameId } of removedEntries) {
-      const roomName = roomNameForGame(gameId);
+      const roomName = getGameRoomName(gameId);
       socket.to(roomName).emit("opponent_disconnected", {
         userId: user.id,
         username: user.username,

--- a/backend/src/socket/helpers.ts
+++ b/backend/src/socket/helpers.ts
@@ -1,0 +1,32 @@
+import type { Socket } from "socket.io";
+
+export type SocketUser = {
+  id: number;
+  username: string;
+  avatarUrl?: string;
+};
+
+export function getSocketUser(socket: Socket): SocketUser {
+  const user = socket.data.user as Partial<SocketUser> | undefined;
+
+  if (!user || typeof user.id !== "number" || typeof user.username !== "string") {
+    throw new Error("Unauthorized");
+  }
+
+  return {
+    id: user.id,
+    username: user.username,
+    avatarUrl: user.avatarUrl,
+  };
+}
+
+export function getGameRoomName(gameId: number): string {
+  return `game-${gameId}`;
+}
+
+export function assertGameId(value: unknown): number {
+  if (!Number.isInteger(value) || Number(value) <= 0) {
+    throw new Error("Invalid gameId");
+  }
+  return Number(value);
+}

--- a/backend/src/socket/index.ts
+++ b/backend/src/socket/index.ts
@@ -3,12 +3,14 @@ import { registerPresenceHandlers, handlePresenceDisconnect } from "./handlers/p
 import { registerChatHandlers } from "./handlers/chat.handlers";
 import { registerMatchmakingHandlers } from "./handlers/matchmaking.handlers";
 import { registerGameRoomHandlers, handleGameRoomDisconnect } from "./handlers/gameRoom.handlers";
+import { registerGameHandlers } from "./handlers/game.handlers";
 
 export function registerSocketHandlers(io: Server, socket: Socket) {
   registerPresenceHandlers(io, socket);
   registerChatHandlers(io, socket);
   registerMatchmakingHandlers(io, socket);
   registerGameRoomHandlers(io, socket);
+  registerGameHandlers(io, socket);
 
   socket.on("disconnect", () => {
     handlePresenceDisconnect(io, socket);


### PR DESCRIPTION
## 🎮 Real-Time Move Events (make_move, game_update)

Closes #146

### Overview

Implements real-time game move events using Socket.io. When a player makes a move, it's validated server-side, saved to the database inside an atomic transaction, and immediately broadcast to both players in the room.

### Changes

#### New Files
- **`backend/src/socket/helpers.ts`** — Shared socket utilities (`getSocketUser`, `getGameRoomName`, `assertGameId`) extracted to avoid duplication across handlers
- **`backend/src/socket/handlers/game.handlers.ts`** — `make_move` event handler with full game logic integration

#### Modified Files
- **`backend/src/socket/index.ts`** — Added `registerGameHandlers` to the socket handler registry
- **`backend/src/socket/handlers/gameRoom.handlers.ts`** — Refactored to use shared helpers from `socket/helpers.ts` (no behavior change)

### Socket Events

| Event | Direction | Description |
|---|---|---|
| `make_move` | Client → Server | Player sends `{ gameId, cellIndex }` |
| `game_update` | Server → Room | Broadcasts new game state to both players |
| `game_over` | Server → Room | Emitted when game ends (win or draw) |
| `move_error` | Server → Client | Sent only to the player who made an invalid move |

### Server-Authoritative Design

- Client only sends `cellIndex` — all game logic runs on the server
- Move validation, win detection, draw detection all happen server-side
- Race conditions handled via Prisma `$transaction` (first valid move wins)
- No optimistic updates — server is the single source of truth

### Error Handling

All invalid moves return a `move_error` event to the sender only:

| Error | Trigger |
|---|---|
| `"Not your turn"` | Player tries to move on opponent's turn |
| `"Cell already occupied"` | Player clicks a filled cell |
| `"Game is not active"` | Game not in `IN_PROGRESS` status |
| `"You are not in this game"` | User is not player1 or player2 |
| `"Invalid cell index"` | cellIndex outside 0-8 range |
| `"Game already finished"` | Move attempted after game over |
| `"Waiting for opponent"` | Game in `WAITING` status |

### Testing

All 7 test scenarios pass:
✅ TEST 1: Valid move (X → cell 4) — both players receive game_update
✅ TEST 2: Invalid move — "Not your turn" error to sender only
✅ TEST 3: Valid move (O → cell 0) — both players receive game_update
✅ TEST 4: Invalid move — "Cell already occupied" error
✅ TEST 5: Invalid move — "Invalid cell index" (cell 99)
✅ TEST 6: Full game to victory — X wins with line [3,4,5], game_over emitted
✅ TEST 7: Move after game finished — "Game already finished" error

text


### Bonus

- `game_over` dedicated event with winner info
- `winningLine` array included in `game_update`/`game_over` for frontend board highlight