### PR TITLE
🐛 fix(game): restore socket reducer refactor after revert

### DIFF
--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -30,7 +30,7 @@ export default function Game() {
   const stateRef = useRef(gameState);
   stateRef.current = gameState;
 
-  const { emitLeaveRoomOnce, resetJoinGuard } = useGameSocketController({
+  const { emitLeaveRoomOnce } = useGameSocketController({
     socket,
     gameId,
     joinRevision,
@@ -58,25 +58,11 @@ export default function Game() {
     if (gameState.disconnectCountdown === null || gameState.disconnectCountdown <= 0) return;
 
     const timer = window.setTimeout(() => {
-      dispatch({
-        type: "PATCH",
-        patch: {
-          disconnectCountdown:
-            gameState.disconnectCountdown && gameState.disconnectCountdown > 0
-              ? gameState.disconnectCountdown - 1
-              : 0,
-        },
-      });
+      dispatch({ type: "DISCONNECT_COUNTDOWN_TICK" });
     }, 1000);
 
     return () => window.clearTimeout(timer);
   }, [gameState.opponentConnection, gameState.disconnectCountdown]);
-
-  useEffect(() => {
-    return () => {
-      emitLeaveRoomOnce();
-    };
-  }, [emitLeaveRoomOnce]);
 
   function handleCellClick(index: number) {
     if (gameState.board[index] !== null) return;
@@ -109,14 +95,11 @@ export default function Game() {
         : gameState.gameOverPayload.winner?.id;
 
     if (!opponentId) {
-      dispatch({
-        type: "PATCH",
-        patch: { rematchError: "Unable to identify opponent for rematch." },
-      });
+      dispatch({ type: "REMATCH_OPPONENT_MISSING" });
       return;
     }
 
-    dispatch({ type: "PATCH", patch: { isCreatingRematch: true, rematchError: null } });
+    dispatch({ type: "REMATCH_REQUEST_START" });
 
     try {
       const newGame = await gamesService.createGame({
@@ -129,38 +112,28 @@ export default function Game() {
     } catch (err: unknown) {
       const message =
         err instanceof ApiError ? err.message : "Failed to create rematch. Please retry.";
-      dispatch({ type: "PATCH", patch: { rematchError: message, isCreatingRematch: false } });
+      dispatch({ type: "REMATCH_REQUEST_FAILED", message });
     }
   }
 
   function handleRetry() {
     if (!navigator.onLine) {
-      dispatch({
-        type: "PATCH",
-        patch: { error: "You are offline. Reconnect to the internet and try again." },
-      });
+      dispatch({ type: "RETRY_OFFLINE" });
       return;
     }
     if (!socket) {
-      dispatch({
-        type: "PATCH",
-        patch: {
-          status: "connecting",
-          error: "Still connecting to server. Please try again in a moment.",
-        },
-      });
+      dispatch({ type: "RETRY_SOCKET_UNAVAILABLE" });
       return;
     }
 
-    resetJoinGuard();
-    dispatch({ type: "PATCH", patch: { error: null, moveError: null, isSendingMove: false } });
+    dispatch({ type: "RETRY_RESET" });
     setJoinRevision((n) => n + 1);
 
     if (!socket.connected) {
       dispatch({ type: "JOIN_CONNECTING" });
       socket.connect();
     } else {
-      dispatch({ type: "PATCH", patch: { status: "idle" } });
+      dispatch({ type: "RETRY_READY" });
     }
   }
 
@@ -338,10 +311,7 @@ export default function Game() {
       />
 
       {isGameOver && gameState.gameOverPayload && !gameState.showGameOverModal ? (
-        <Button
-          variant="secondary"
-          onClick={() => dispatch({ type: "PATCH", patch: { showGameOverModal: true } })}
-        >
+        <Button variant="secondary" onClick={() => dispatch({ type: "OPEN_GAME_OVER_MODAL" })}>
           View Result
         </Button>
       ) : null}
@@ -365,7 +335,7 @@ export default function Game() {
         }}
         onGoLobby={backToLobby}
         onGoHome={goHome}
-        onClose={() => dispatch({ type: "PATCH", patch: { showGameOverModal: false } })}
+        onClose={() => dispatch({ type: "CLOSE_GAME_OVER_MODAL" })}
       />
     </div>
   );

--- a/frontend/src/pages/game/state.ts
+++ b/frontend/src/pages/game/state.ts
@@ -47,8 +47,19 @@ export type GameAction =
   | { type: "JOIN_START" }
   | { type: "INVALID_GAME_ID"; message: string }
   | { type: "BEGIN_MOVE_SEND" }
+  | { type: "DISCONNECT_COUNTDOWN_TICK" }
+  | { type: "REMATCH_RECEIVED" }
+  | { type: "REMATCH_REQUEST_START" }
+  | { type: "REMATCH_REQUEST_FAILED"; message: string }
+  | { type: "REMATCH_OPPONENT_MISSING" }
+  | { type: "RETRY_OFFLINE" }
+  | { type: "RETRY_SOCKET_UNAVAILABLE" }
+  | { type: "RETRY_RESET" }
+  | { type: "RETRY_READY" }
+  | { type: "OPEN_GAME_OVER_MODAL" }
+  | { type: "CLOSE_GAME_OVER_MODAL" }
   | { type: "RESET_FOR_ROUTE_CHANGE" }
-  | { type: "PATCH"; patch: Partial<GameViewState> };
+  ;
 
 export const initialGameState: GameViewState = {
   status: "idle",
@@ -257,10 +268,52 @@ export function gameReducer(state: GameViewState, action: GameAction): GameViewS
       return { ...state, status: "idle", error: action.message };
     case "BEGIN_MOVE_SEND":
       return { ...state, isSendingMove: true, moveError: null };
+    case "DISCONNECT_COUNTDOWN_TICK":
+      return {
+        ...state,
+        disconnectCountdown:
+          state.disconnectCountdown && state.disconnectCountdown > 0
+            ? state.disconnectCountdown - 1
+            : 0,
+      };
+    case "REMATCH_RECEIVED":
+      return { ...state, isCreatingRematch: true, rematchError: null };
+    case "REMATCH_REQUEST_START":
+      return { ...state, isCreatingRematch: true, rematchError: null };
+    case "REMATCH_REQUEST_FAILED":
+      return { ...state, rematchError: action.message, isCreatingRematch: false };
+    case "REMATCH_OPPONENT_MISSING":
+      return {
+        ...state,
+        rematchError: "Unable to identify opponent for rematch.",
+        isCreatingRematch: false,
+      };
+    case "RETRY_OFFLINE":
+      return {
+        ...state,
+        error: "You are offline. Reconnect to the internet and try again.",
+      };
+    case "RETRY_SOCKET_UNAVAILABLE":
+      return {
+        ...state,
+        status: "connecting",
+        error: "Still connecting to server. Please try again in a moment.",
+      };
+    case "RETRY_RESET":
+      return {
+        ...state,
+        error: null,
+        moveError: null,
+        isSendingMove: false,
+      };
+    case "RETRY_READY":
+      return { ...state, status: "idle" };
+    case "OPEN_GAME_OVER_MODAL":
+      return { ...state, showGameOverModal: true };
+    case "CLOSE_GAME_OVER_MODAL":
+      return { ...state, showGameOverModal: false };
     case "RESET_FOR_ROUTE_CHANGE":
       return { ...state, status: "idle" };
-    case "PATCH":
-      return { ...state, ...action.patch };
     default:
       return state;
   }

--- a/frontend/src/pages/game/useGameSocketController.ts
+++ b/frontend/src/pages/game/useGameSocketController.ts
@@ -34,6 +34,7 @@ export function useGameSocketController({
   const joinedRef = useRef(false);
   const leftRoomRef = useRef(false);
   const activeRoomIdRef = useRef<number | null>(null);
+  const lastJoinRevisionRef = useRef(joinRevision);
 
   const emitLeaveRoomOnce = useCallback(() => {
     if (!socket) return;
@@ -85,7 +86,7 @@ export function useGameSocketController({
     }
 
     function onRematchReceived({ newGameId }: { newGameId: number }) {
-      dispatch({ type: "PATCH", patch: { isCreatingRematch: true, rematchError: null } });
+      dispatch({ type: "REMATCH_RECEIVED" });
       void navigate(`/game/${newGameId}`);
     }
 
@@ -218,6 +219,13 @@ export function useGameSocketController({
   }, [socket, gameId, dispatch, stateRef]);
 
   useEffect(() => {
+    if (joinRevision === lastJoinRevisionRef.current) return;
+    lastJoinRevisionRef.current = joinRevision;
+    joinedRef.current = false;
+    leftRoomRef.current = false;
+  }, [joinRevision]);
+
+  useEffect(() => {
     if (!socket || !gameId) return;
 
     const previousRoomId = activeRoomIdRef.current;
@@ -266,5 +274,11 @@ export function useGameSocketController({
     startJoin();
   }, [socket, gameId, joinRevision, dispatch]);
 
-  return { emitLeaveRoomOnce, resetJoinGuard: () => { joinedRef.current = false; } };
+  useEffect(() => {
+    return () => {
+      emitLeaveRoomOnce();
+    };
+  }, [emitLeaveRoomOnce]);
+
+  return { emitLeaveRoomOnce };
 }


### PR DESCRIPTION
## 📌 Summary

Re-applies and finalizes the Game socket reducer/controller refactor after PR #217 was reverted, and includes the follow-up blocking fixes.

## 🚀 Changes

- Re-introduce reducer/controller-based socket lifecycle in `Game` page flow.
- Remove reducer `PATCH` backdoor and replace with explicit named actions.
- Keep room leave lifecycle encapsulated in the controller (including unmount cleanup).
- Remove external join-guard ref mutation API and keep join reset internal to controller.

## 🧪 Testing

- [x] `npm run test:unit --prefix frontend -- tests/unit/Game.test.tsx`
- [x] `npm run lint --prefix frontend`

## 🔗 Context

- Original merged PR: #217
- Revert branch/commit removed it from `main`; this PR restores the intended implementation with additional fixes.
