### PR TITLE
fix(game): robust lifecycle cleanup — sync unmount emit, tab-close, stale-game auto-forfeit

### DIFF
--- a/backend/src/services/disconnection.service.ts
+++ b/backend/src/services/disconnection.service.ts
@@ -65,7 +65,7 @@ class DisconnectionService {
   }
 
   // Exécute la logique de forfait en DB et prévient les clients
-  private async handleForfeit(
+  async handleForfeit(
     io: Server,
     gameId: number,
     loser: { id: number; username: string; symbol: string },

--- a/backend/src/socket/handlers/gameRoom.handlers.ts
+++ b/backend/src/socket/handlers/gameRoom.handlers.ts
@@ -86,6 +86,23 @@ export function registerGameRoomHandlers(io: Server, socket: Socket) {
           return;
         }
 
+        // If the game has already ended, notify the client and do not join the room
+        const terminalStatuses = ["ABANDONED", "FINISHED", "DRAW", "CANCELLED"];
+        if (terminalStatuses.includes(game.status)) {
+          const endedPayload = buildJoinedPayload(game);
+          const yourSymbol =
+            game.player1Id === user.id ? game.player1Symbol : game.player2Symbol;
+          socket.emit("game_already_ended", {
+            ...endedPayload,
+            game: {
+              ...(endedPayload.game as Record<string, unknown>),
+              yourSymbol,
+            },
+          });
+          callback?.({ error: "Game has already ended", status: game.status });
+          return;
+        }
+
         const roomName = getGameRoomName(gameId);
 
         const cancelled = disconnectionService.cancelForfeitTimer(gameId, user.id);

--- a/backend/src/socket/handlers/matchmaking.handlers.ts
+++ b/backend/src/socket/handlers/matchmaking.handlers.ts
@@ -2,6 +2,9 @@ import type { Server, Socket } from "socket.io";
 import prisma from "../../lib/prisma";
 import { matchmakingService } from "../services/matchmaking.service";
 import { createGameInDb } from "../../services/games.service";
+import { gameRoomService } from "../services/gameRoom.service";
+import { disconnectionService } from "../../services/disconnection.service";
+import { getGameRoomName } from "../helpers";
 
 export function registerMatchmakingHandlers(io: Server, socket: Socket) {
   const userId: number = socket.data.user.id;
@@ -18,9 +21,57 @@ export function registerMatchmakingHandlers(io: Server, socket: Socket) {
           OR: [{ player1Id: userId }, { player2Id: userId }],
           status: "IN_PROGRESS",
         },
+        include: {
+          player1: { select: { id: true, username: true } },
+          player2: { select: { id: true, username: true } },
+        },
       });
       if (activeGame) {
-        return socket.emit("error", { message: "Already in an active game" });
+        // Check if the player is actually in the game room
+        const playersInRoom = gameRoomService.getPlayersInRoom(activeGame.id);
+        const isInRoom = playersInRoom.some((p) => p.userId === userId);
+
+        if (isInRoom) {
+          return socket.emit("error", { message: "Already in an active game" });
+        }
+
+        // Player is not in the room — auto-forfeit the stale game
+        if (process.env.NODE_ENV === "development") {
+          console.log(
+            `[Matchmaking] Auto-forfeiting stale game ${activeGame.id} for user ${userId}`,
+          );
+        }
+
+        const isPlayer1 = activeGame.player1Id === userId;
+        const opponent = isPlayer1 ? activeGame.player2 : activeGame.player1;
+
+        if (opponent) {
+          const disconnectedSymbol = isPlayer1
+            ? activeGame.player1Symbol
+            : activeGame.player2Symbol;
+          const opponentSymbol = isPlayer1
+            ? activeGame.player2Symbol
+            : activeGame.player1Symbol;
+          const roomName = getGameRoomName(activeGame.id);
+
+          await disconnectionService.handleForfeit(
+            io,
+            activeGame.id,
+            {
+              id: userId,
+              username: socket.data.user.username,
+              symbol: disconnectedSymbol,
+            },
+            { id: opponent.id, username: opponent.username, symbol: opponentSymbol },
+            roomName,
+          );
+        } else {
+          // No opponent — just mark as abandoned
+          await prisma.game.update({
+            where: { id: activeGame.id },
+            data: { status: "ABANDONED", finishedAt: new Date() },
+          });
+        }
       }
 
       matchmakingService.addToQueue({

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -37,6 +37,18 @@ export default function Game() {
     stateRef,
   });
 
+  // Emit leave_game_room on tab close / refresh so the server cleans up
+  // immediately rather than waiting for the socket disconnect timeout.
+  useEffect(() => {
+    function handleBeforeUnload() {
+      if (socket && gameId) {
+        socket.emit("leave_game_room", { gameId });
+      }
+    }
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [socket, gameId]);
+
   useEffect(() => {
     if (gameState.startedAtMs === null || gameState.serverStatus !== "IN_PROGRESS") {
       return;

--- a/frontend/src/pages/game/useGameSocketController.ts
+++ b/frontend/src/pages/game/useGameSocketController.ts
@@ -60,6 +60,8 @@ export function useGameSocketController({
   dispatch,
   stateRef,
 }: UseGameSocketControllerParams) {
+  const socketRef = useRef(socket);
+  socketRef.current = socket;
   const activeRoomIdRef = useRef<number | null>(null);
   const lastJoinRevisionRef = useRef(joinRevision);
   const receivedEventsRef = useRef({
@@ -160,6 +162,12 @@ export function useGameSocketController({
       void navigate(`/game/${newGameId}`);
     }
 
+    function onGameAlreadyEnded() {
+      if (import.meta.env.DEV)
+        console.log("[Game] Game already ended, redirecting to lobby");
+      void navigate("/lobby");
+    }
+
     socket.on("room_joined", onRoomJoined);
     socket.on("game_update", onGameUpdate);
     socket.on("game_over", onGameOver);
@@ -167,6 +175,7 @@ export function useGameSocketController({
     socket.on("error", onError);
     socket.on("disconnect", onDisconnect);
     socket.on("rematch_received", onRematchReceived);
+    socket.on("game_already_ended", onGameAlreadyEnded);
 
     return () => {
       socket.off("room_joined", onRoomJoined);
@@ -176,6 +185,7 @@ export function useGameSocketController({
       socket.off("error", onError);
       socket.off("disconnect", onDisconnect);
       socket.off("rematch_received", onRematchReceived);
+      socket.off("game_already_ended", onGameAlreadyEnded);
     };
   }, [socket, gameId, navigate, dispatch, stateRef]);
 
@@ -371,9 +381,20 @@ export function useGameSocketController({
   // ── Cleanup on unmount ──
   useEffect(() => {
     return () => {
-      emitLeaveRoomOnce();
+      // On unmount, emit leave_game_room synchronously — bypass the debounce
+      // because the component is being destroyed and a debounced call may
+      // never fire.
+      if (joinState.leaveTimeout) {
+        clearTimeout(joinState.leaveTimeout);
+        joinState.leaveTimeout = null;
+      }
+      const roomId = joinState.joinedGameId;
+      if (roomId && socketRef.current) {
+        socketRef.current.emit("leave_game_room", { gameId: roomId });
+        joinState.joinedGameId = null;
+      }
     };
-  }, [emitLeaveRoomOnce]);
+  }, []);
 
   return { emitLeaveRoomOnce };
 }


### PR DESCRIPTION
## Summary

Fixes a cluster of game lifecycle bugs (parent issue #152 Phase 4 multiplayer testing) where players could get permanently locked into a broken game state after quitting, navigating away, or closing the tab.

- Closes #218
- Closes #227
- Closes #236

---

## Problem

Four distinct failure modes were identified during multiplayer testing:

1. **#218** — After one player quits mid-game, the other player could not start a new game. The matchmaking handler blocked them with "Already in an active game" even though they were no longer in the room.
2. **#227** — Navigating home via the Home button left the player's game record stuck as `IN_PROGRESS`, so `find_game` would always reject them.
3. **#236** — The `leave_game_room` emit in `useGameSocketController` was wrapped in a 150 ms debounced flush, which could silently fail to fire during a React unmount. Navigation away would never trigger a disconnect.
4. **#152 Test 10** — The Play Again flow was broken by a terminal-state guard missing on `join_game_room`, causing the backend to accept a re-join into a `FINISHED` game.

---

## Changes

### Frontend

**`useGameSocketController.ts`**
- Replaced the debounced-flush unmount emit with a direct synchronous `socket.emit("leave_game_room", ...)` call to guarantee the event fires during React cleanup.
- Added `socketRef` to capture the socket instance at mount time so the unmount closure is never stale.
- Added a `game_already_ended` socket listener that redirects to the lobby, handling the case where a player lands on a game that has already concluded.

**`Game.tsx`**
- Added a `beforeunload` event handler that emits `leave_game_room` synchronously on tab close or page refresh, covering the window-close scenario that socket disconnect alone could not handle cleanly.

### Backend

**`matchmaking.handlers.ts`**
- On `find_game`, when a player has an `IN_PROGRESS` game but is **not** present in the Socket.io room for that game, the handler now auto-forfeits the stale game (via `handleForfeit`) and proceeds with matchmaking instead of returning an error. This resolves the "locked in active game" states after unclean exits.

**`gameRoom.handlers.ts`**
- Added a terminal-state guard on `join_game_room`: if the requested game is `ABANDONED`, `FINISHED`, `DRAW`, or `CANCELLED`, the handler emits `game_already_ended` back to the client and returns early instead of allowing a re-join into a dead game.

**`disconnection.service.ts`**
- Changed `handleForfeit` from `private` to `public` so `matchmaking.handlers.ts` can invoke it directly for the auto-forfeit path.

---

## Testing

- [x] Backend lint: clean
- [x] Frontend lint: clean
- [x] Backend tests: 38/38 passed (7 suites)
- [x] Manual two-browser testing — all 4 scenarios verified:
  - Navigate away mid-game triggers `leave_game_room` and unblocks the opponent
  - Tab close / page refresh emits via `beforeunload`
  - Starting a new game after an unclean exit auto-forfeits the stale game and enters matchmaking normally
  - Play Again flow works end-to-end without hitting a stale `FINISHED` game

---

## Risks / Notes

- The `beforeunload` emit is best-effort — browsers may not guarantee async operations complete during unload. This is a known platform limitation and is acceptable here since the socket disconnect will also fire shortly after.
- `handleForfeit` is now public, which widens its call surface slightly. It remains internal to the service layer and is not exposed over the network.

---

## Checklist

- [x] Self-review completed
- [x] No unrelated changes included
- [x] Tests and manual verification documented above