### PR TITLE
fix(game): persist winningLine and restore completed game state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,13 @@ shell-db:			## Open psql in database container
 
 # ── Database ────────────────────────────────────────────────────────────────
 
-db-migrate:			## Run Prisma migrations
+db-migrate:			## Run Prisma migrations + regenerate client (container + host)
 	$(COMPOSE) exec backend npx prisma migrate dev
+	cd backend && npx prisma generate
+
+db-generate:		## Regenerate Prisma client (container + host)
+	$(COMPOSE) exec backend npx prisma generate
+	cd backend && npx prisma generate
 
 db-studio:			## Open Prisma Studio (DB browser)
 	$(COMPOSE) exec backend npx prisma studio
@@ -96,4 +101,4 @@ help:				## Show this help
 .PHONY: all build up down stop start clean fclean re \
         logs logs-back logs-front logs-db ps \
         shell-back shell-front shell-db \
-        db-migrate db-studio db-seed help
+        db-migrate db-generate db-studio db-seed help

--- a/backend/prisma/migrations/20260308200407_add_winning_line/migration.sql
+++ b/backend/prisma/migrations/20260308200407_add_winning_line/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "games" ADD COLUMN     "winning_line" JSONB;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -65,6 +65,7 @@ model Game {
   startedAt     DateTime? @map("started_at")
   createdAt    DateTime   @default(now()) @map("created_at")
   finishedAt   DateTime?  @map("finished_at")
+  winningLine  Json?      @map("winning_line")
 
   // Tournament link (nullable: not all games are tournament games)
   tournamentId Int?       @map("tournament_id")

--- a/backend/src/services/games.service.ts
+++ b/backend/src/services/games.service.ts
@@ -426,6 +426,7 @@ export const makeMoveInDb = async (gameId: number, cellIndex: number, userId: nu
       updateData.winnerId =
         result.winner === game.player1Symbol ? game.player1Id : game.player2Id;
       updateData.finishedAt = new Date();
+      updateData.winningLine = result.line ?? null;
     } else if (result.gameOver && result.isDraw) {
       updateData.status = "DRAW";
       updateData.winnerId = null;

--- a/backend/src/socket/handlers/gameRoom.handlers.ts
+++ b/backend/src/socket/handlers/gameRoom.handlers.ts
@@ -52,7 +52,10 @@ function emitError(socket: Socket, message: string, callback?: AckCallback) {
 /** Build the payload sent with room_joined / game_already_ended.
  *  Accepts the raw Prisma result (with gamePlayersSelect included). */
 function buildJoinedPayload(
-  game: Awaited<ReturnType<typeof prisma.game.findUnique>> & { player1: unknown; player2: unknown },
+  game: Awaited<ReturnType<typeof prisma.game.findUnique>> & {
+    player1: unknown;
+    player2: unknown;
+  },
 ): Record<string, unknown> {
   return {
     gameId: game.id,
@@ -72,6 +75,7 @@ function buildJoinedPayload(
       createdAt: game.createdAt,
       startedAt: game.startedAt,
       finishedAt: game.finishedAt,
+      winningLine: game.winningLine,
     },
   };
 }
@@ -166,7 +170,11 @@ export function registerGameRoomHandlers(io: Server, socket: Socket) {
 
         const isPlayer = game.player1Id === user.id || game.player2Id === user.id;
         if (!isPlayer) {
-          emitError(socket, "Unauthorized: You are not a participant in this game", callback);
+          emitError(
+            socket,
+            "Unauthorized: You are not a participant in this game",
+            callback,
+          );
           return;
         }
 
@@ -217,8 +225,12 @@ export function registerGameRoomHandlers(io: Server, socket: Socket) {
           return;
         }
 
-        const { yourSymbol, opponentId, opponent: opponentUser, role } =
-          resolveRoles(syncedGame, user.id);
+        const {
+          yourSymbol,
+          opponentId,
+          opponent: opponentUser,
+          role,
+        } = resolveRoles(syncedGame, user.id);
         const payloadForClient = buildJoinedPayload(syncedGame);
 
         // Check if the opponent has an active forfeit timer (i.e. they are

--- a/frontend/src/pages/game/gameEndedHelpers.ts
+++ b/frontend/src/pages/game/gameEndedHelpers.ts
@@ -1,0 +1,54 @@
+import type { PlayerSymbol, RoomPlayerSummary } from "../../types/game";
+import type { ServerStatus } from "./types";
+
+/** Shape of the game object inside a `game_already_ended` payload. */
+export interface EndedGameData {
+  status?: ServerStatus;
+  boardState?: import("../../types/game").Board;
+  yourSymbol?: PlayerSymbol;
+  player1?: RoomPlayerSummary;
+  player2?: RoomPlayerSummary | null;
+  player1Symbol?: PlayerSymbol;
+  player2Symbol?: PlayerSymbol;
+  winnerId?: number | null;
+  startedAt?: string | null;
+  finishedAt?: string | null;
+  winningLine?: number[] | null;
+}
+
+const DEFAULT_PLAYER: RoomPlayerSummary = { id: 0, username: "Player 1", avatarUrl: null };
+
+/** Build the game object expected by the ROOM_JOINED dispatch. */
+export function buildRoomJoinedGame(game: EndedGameData, status: ServerStatus) {
+  return {
+    boardState: game.boardState!,
+    currentTurn: game.yourSymbol!,
+    status,
+    yourSymbol: game.yourSymbol!,
+    player1: game.player1 ?? DEFAULT_PLAYER,
+    player2: game.player2 ?? null,
+    player1Symbol: game.player1Symbol ?? ("X" as PlayerSymbol),
+    player2Symbol: game.player2Symbol ?? ("O" as PlayerSymbol),
+    startedAt: game.startedAt ?? null,
+  };
+}
+
+/** Resolve winner/loser players and symbols from winnerId. */
+export function resolveWinnerLoser(game: EndedGameData) {
+  const isP1Winner = game.winnerId === game.player1?.id;
+  return {
+    winnerPlayer: isP1Winner ? game.player1 : game.player2,
+    loserPlayer: isP1Winner ? game.player2 : game.player1,
+    winnerSymbol: (isP1Winner ? game.player1Symbol : game.player2Symbol) ?? ("X" as PlayerSymbol),
+    loserSymbol: (isP1Winner ? game.player2Symbol : game.player1Symbol) ?? ("O" as PlayerSymbol),
+  };
+}
+
+/** Check if the reconnecting player is the winner. */
+export function didPlayerWin(game: EndedGameData): boolean {
+  return (
+    game.winnerId != null &&
+    ((game.player1?.id === game.winnerId && game.yourSymbol === game.player1Symbol) ||
+      (game.player2?.id === game.winnerId && game.yourSymbol === game.player2Symbol))
+  );
+}

--- a/frontend/src/pages/game/state.ts
+++ b/frontend/src/pages/game/state.ts
@@ -338,6 +338,9 @@ export function gameReducer(state: GameViewState, action: GameAction): GameViewS
       return { ...state, showGameOverModal: false };
 
     case "RESET_FOR_ROUTE_CHANGE":
+      // Don't reset if game results are already showing — prevents a StrictMode
+      // race where this action fires after game_already_ended has set the state.
+      if (state.showGameOverModal) return state;
       return { ...state, status: "idle" };
 
     default:

--- a/frontend/src/pages/game/useGameSocketController.ts
+++ b/frontend/src/pages/game/useGameSocketController.ts
@@ -3,6 +3,8 @@ import type { Socket } from "socket.io-client";
 import type { NavigateFunction } from "react-router-dom";
 
 import type { RoomPlayerSummary } from "../../types/game";
+import { buildRoomJoinedGame, resolveWinnerLoser, didPlayerWin } from "./gameEndedHelpers";
+import type { EndedGameData } from "./gameEndedHelpers";
 import type {
   GameForfeited,
   GameOver,
@@ -189,80 +191,66 @@ export function useGameSocketController({
       void navigate(`/game/${newGameId}`);
     }
 
-    function onGameAlreadyEnded(data?: {
-      gameId?: number;
-      game?: {
-        status?: string;
-        boardState?: import("../../types/game").Board;
-        yourSymbol?: import("../../types/game").PlayerSymbol;
-        player1?: import("../../types/game").RoomPlayerSummary;
-        player2?: import("../../types/game").RoomPlayerSummary | null;
-        player1Symbol?: import("../../types/game").PlayerSymbol;
-        player2Symbol?: import("../../types/game").PlayerSymbol;
-        winnerId?: number | null;
-        startedAt?: string | null;
-      };
-    }) {
+    function onGameAlreadyEnded(data?: { gameId?: number; game?: EndedGameData }) {
       const game = data?.game;
-      if (game?.status === "ABANDONED" && game.boardState && game.yourSymbol) {
-        // Show the forfeit result instead of redirecting
-        dispatch({
-          type: "ROOM_JOINED",
-          game: {
-            boardState: game.boardState,
-            currentTurn: game.yourSymbol,
-            status: "ABANDONED" as const,
-            yourSymbol: game.yourSymbol,
-            player1: game.player1 ?? { id: 0, username: "Player 1", avatarUrl: null },
-            player2: game.player2 ?? null,
-            player1Symbol: game.player1Symbol ?? "X",
-            player2Symbol: game.player2Symbol ?? "O",
-            startedAt: game.startedAt ?? null,
-          },
-        });
-        // Determine if this player won
-        const didWin =
-          game.winnerId != null &&
-          ((game.player1?.id === game.winnerId &&
-            game.yourSymbol === game.player1Symbol) ||
-            (game.player2?.id === game.winnerId &&
-              game.yourSymbol === game.player2Symbol));
-        const winnerPlayer =
-          game.winnerId === game.player1?.id ? game.player1 : game.player2;
-        const loserPlayer =
-          game.winnerId === game.player1?.id ? game.player2 : game.player1;
-        const winnerSymbol =
-          game.winnerId === game.player1?.id ? game.player1Symbol : game.player2Symbol;
-        const loserSymbol =
-          game.winnerId === game.player1?.id ? game.player2Symbol : game.player1Symbol;
+      if (!game?.boardState || !game.yourSymbol) {
+        if (import.meta.env.DEV)
+          console.log("[Game] Game already ended, redirecting to lobby");
+        void navigate("/lobby");
+        return;
+      }
+
+      const id = data?.gameId ?? gameId;
+      const { winnerPlayer, loserPlayer, winnerSymbol, loserSymbol } = resolveWinnerLoser(game);
+
+      // Restore board state for any terminal status
+      dispatch({ type: "ROOM_JOINED", game: buildRoomJoinedGame(game, game.status!) });
+
+      if (game.status === "ABANDONED") {
         dispatch({
           type: "GAME_FORFEITED",
           payload: {
-            gameId: data?.gameId ?? gameId,
+            gameId: id,
             finalBoard: game.boardState,
             result: "win",
             winner: winnerPlayer
-              ? {
-                  id: winnerPlayer.id,
-                  username: winnerPlayer.username,
-                  symbol: winnerSymbol ?? "X",
-                }
+              ? { id: winnerPlayer.id, username: winnerPlayer.username, symbol: winnerSymbol }
               : undefined,
             loser: loserPlayer
-              ? {
-                  id: loserPlayer.id,
-                  username: loserPlayer.username,
-                  symbol: loserSymbol ?? "O",
-                }
+              ? { id: loserPlayer.id, username: loserPlayer.username, symbol: loserSymbol }
               : undefined,
           },
-          didWin,
+          didWin: didPlayerWin(game),
         });
         return;
       }
-      if (import.meta.env.DEV)
-        console.log("[Game] Game already ended, redirecting to lobby");
-      void navigate("/lobby");
+
+      if (game.status === "FINISHED" || game.status === "DRAW") {
+        const isDraw = game.status === "DRAW";
+        const duration =
+          game.startedAt && game.finishedAt
+            ? Math.round(
+                (new Date(game.finishedAt).getTime() - new Date(game.startedAt).getTime()) / 1000,
+              )
+            : undefined;
+        dispatch({
+          type: "GAME_OVER",
+          payload: {
+            gameId: id,
+            finalBoard: game.boardState,
+            result: isDraw ? "draw" : "win",
+            winner: !isDraw && winnerPlayer
+              ? { id: winnerPlayer.id, username: winnerPlayer.username, symbol: winnerSymbol }
+              : undefined,
+            loser: !isDraw && loserPlayer
+              ? { id: loserPlayer.id, username: loserPlayer.username, symbol: loserSymbol }
+              : undefined,
+            winningLine: game.winningLine ?? null,
+            duration,
+          },
+          didWin: !isDraw && didPlayerWin(game),
+        });
+      }
     }
 
     socket.on("connect", onConnect);


### PR DESCRIPTION
## Summary

- **#274**: Reconnecting to a FINISHED/DRAW game now shows the result screen with winning line, winner/loser, and duration — instead of redirecting to lobby
- **#280**: Game duration computed from DB timestamps (`finishedAt - startedAt`), winner perspective resolved from `winnerId`
- **winningLine** persisted in DB on game end, sent via `game_already_ended` event
- Extracted `gameEndedHelpers.ts` to DRY up repeated winner/loser resolution logic
- Fixed StrictMode race condition where `RESET_FOR_ROUTE_CHANGE` could overwrite game results
- Added `db-migrate` / `db-generate` Makefile rules for container + host Prisma sync

## Test plan

- [x] Play a game to completion (win), close tab, reopen `/game/:id` → result screen with highlighted winning line
- [x] Play a game to draw, close tab, reopen → result screen showing "Draw game"
- [x] Close browser during game, wait for forfeit, reopen → forfeit result screen
- [x] Verify `winning_line` column populated in DB via `make db-studio`
- [x] Repeatedly navigate to `/game/:id` for ended game → consistent result (no flicker to error page)