### PR TITLE
fix: protect tournament routes behind auth

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,7 +22,7 @@ import ToastContainer from "./components/Toast";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService";
 
-import { useParams } from "react-router-dom"; //
+import { useParams } from "react-router-dom";
 
 function HomeLayout() {
   return (
@@ -61,12 +61,10 @@ function Layout() {
   );
 }
 
-//
 function GameWrapper() {
   const { id } = useParams();
   return <Game key={id} />;
 }
-//
 
 function App() {
   return (
@@ -81,8 +79,6 @@ function App() {
           <Route element={<Layout />}>
             <Route path="/login" element={<Login />} />
             <Route path="/signup" element={<Signup />} />
-            <Route path="/tournaments" element={<Tournaments />} />
-            <Route path="/tournaments/:id" element={<TournamentDetail />} />
             <Route path="/leaderboard" element={<Leaderboard />} />
             <Route path="/privacy" element={<PrivacyPolicy />} />
             <Route path="/terms" element={<TermsOfService />} />
@@ -94,9 +90,11 @@ function App() {
               <Route path="/lobby" element={<GameLobby />} />
               <Route path="/game" element={<Navigate to="/lobby" replace />} />
               <Route path="/game/local" element={<LocalGame />} />
-              <Route path="/game/:id" element={<GameWrapper />} /> {/**/}
+              <Route path="/game/:id" element={<GameWrapper />} />
               <Route path="/matchmaking" element={<Matchmaking />} />
               <Route path="/ai-game" element={<AIGame />} />
+              <Route path="/tournaments" element={<Tournaments />} />
+              <Route path="/tournaments/:id" element={<TournamentDetail />} />
             </Route>
           </Route>
         </Routes>

--- a/frontend/tests/e2e/protected-routes.spec.ts
+++ b/frontend/tests/e2e/protected-routes.spec.ts
@@ -61,6 +61,26 @@ test.describe("Protected routes — access control", () => {
       await expect(page).toHaveURL("/game");
     });
 
+    test("can access /tournaments after login", async ({ page }) => {
+      await loginAndGetToken(page);
+
+      await page.goto("/tournaments");
+      await page.waitForLoadState("networkidle");
+
+      await expect(page).not.toHaveURL("/login");
+      await expect(page).toHaveURL("/tournaments");
+    });
+
+    test("can access /tournaments/:id after login", async ({ page }) => {
+      await loginAndGetToken(page);
+
+      await page.goto("/tournaments/test-tournament-id");
+      await page.waitForLoadState("networkidle");
+
+      await expect(page).not.toHaveURL("/login");
+      await expect(page).toHaveURL("/tournaments/test-tournament-id");
+    });
+
     test("profile page displays user data (from GET /api/auth/me)", async ({ page }) => {
       await loginAndGetToken(page);
 
@@ -86,6 +106,20 @@ test.describe("Protected routes — access control", () => {
 
     test("redirects /game to /login when not logged in", async ({ page }) => {
       await page.goto("/game");
+      await page.waitForLoadState("networkidle");
+
+      await expect(page).toHaveURL("/login", { timeout: 5000 });
+    });
+
+    test("redirects /tournaments to /login when not logged in", async ({ page }) => {
+      await page.goto("/tournaments");
+      await page.waitForLoadState("networkidle");
+
+      await expect(page).toHaveURL("/login", { timeout: 5000 });
+    });
+
+    test("redirects /tournaments/:id to /login when not logged in", async ({ page }) => {
+      await page.goto("/tournaments/test-tournament-id");
       await page.waitForLoadState("networkidle");
 
       await expect(page).toHaveURL("/login", { timeout: 5000 });


### PR DESCRIPTION
## Summary

This PR fixes issue #297 by protecting tournament pages behind authentication.

## Changes

- moved `/tournaments` under `ProtectedRoute`
- moved `/tournaments/:id` under `ProtectedRoute`
- added E2E coverage for tournament protected routes

## Why

Tournament pages were accessible from the frontend without authentication,
while the backend API was already protected.
This made the routing behavior inconsistent.

## Tested

- unauthenticated user is redirected from `/tournaments` to `/login`
- unauthenticated user is redirected from `/tournaments/:id` to `/login`
- authenticated user can access `/tournaments`
- authenticated user can access `/tournaments/:id`