### PR TITLE
fix(tournament): auto-register creator on tournament creation

### DIFF
--- a/backend/src/services/tournaments.service.ts
+++ b/backend/src/services/tournaments.service.ts
@@ -24,24 +24,38 @@ export async function createTournament(
   maxPlayers: 4 | 8,
   createdById: number,
 ) {
-  return prisma.tournament.create({
-    data: {
-      name,
-      maxPlayers,
-      createdById,
-    },
-    include: {
-      creator: {
-        select: { id: true, username: true },
+  return prisma.$transaction(async (tx) => {
+    const tournament = await tx.tournament.create({
+      data: {
+        name,
+        maxPlayers,
+        createdById,
       },
-      participants: {
-        include: {
-          user: {
-            select: { id: true, username: true, avatarUrl: true },
+    });
+
+    await tx.tournamentParticipant.create({
+      data: {
+        tournamentId: tournament.id,
+        userId: createdById,
+        seed: 1,
+      },
+    });
+
+    return tx.tournament.findUniqueOrThrow({
+      where: { id: tournament.id },
+      include: {
+        creator: {
+          select: { id: true, username: true },
+        },
+        participants: {
+          include: {
+            user: {
+              select: { id: true, username: true, avatarUrl: true },
+            },
           },
         },
       },
-    },
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

Fixes issue #293 by automatically registering the tournament creator as the first participant when the tournament is created.

## Changes

- wrap `createTournament()` in a transaction
- create the tournament
- create the creator entry in `TournamentParticipant` with `seed: 1`
- return the tournament with the same included relations as before

## Why

The tournament creator was creating the tournament but was not registered in it automatically, which forced an unnecessary manual join and caused inconsistent UX.

This PR keeps the implementation minimal and follows the existing service flow.

## Manual test

- create a tournament
- open tournament details
- creator is already present in participants list
- creator is registered with seed 1

Closes #293