### PR TITLE
fix(tournaments): hide tournament banner on game page

### DIFF
--- a/frontend/src/components/ActiveTournamentBanner.tsx
+++ b/frontend/src/components/ActiveTournamentBanner.tsx
@@ -14,7 +14,12 @@ export default function ActiveTournamentBanner() {
     activeTournamentId !== null &&
     location.pathname === `/tournaments/${activeTournamentId}`;
 
-  if (!activeTournamentId || isOnTournamentPage) return null;
+  const isOnGamePage =
+    activeTournamentId !== null && location.pathname.startsWith("/game/");
+
+  if (!activeTournamentId || isOnTournamentPage || isOnGamePage) {
+    return null;
+  }
 
   return (
     <div className="fixed bottom-16 left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-lg border border-pong-secondary/30 bg-pong-surface/95 px-4 py-2.5 shadow-lg backdrop-blur-md">


### PR DESCRIPTION
**Summary**  
Fixes issue #310 by hiding the active tournament banner while viewing a game page.

**Changes**  
- hide `ActiveTournamentBanner` on `/game/:id`
- keep existing `Rejoin` behavior unchanged everywhere else

**Why**  
The active tournament banner was already hidden on `/tournaments/:id`, but it still appeared on the associated match page `/game/:id`, which is redundant while the player is already inside the tournament flow.

**Manual test**  
- join a tournament and reach an active tournament state
- open `/tournaments/:id` → banner is hidden
- enter the bracket match `/game/:id` → banner is hidden
- go back to another page like lobby/profile → banner is visible again
- click `Rejoin` → still redirects to `/tournaments/:id`

**Closes**  
`Closes #310`