### PR TITLE
fix(tournament): prevent non-participants from opening finished match games (#315)

### DIFF
--- a/frontend/src/components/Tournament/BracketView.tsx
+++ b/frontend/src/components/Tournament/BracketView.tsx
@@ -130,7 +130,7 @@ function MatchCard({
   const isMyMatch =
     currentUserId != null &&
     (player1?.id === currentUserId || player2?.id === currentUserId);
-  const isClickable = hasGame && (isComplete || isMyMatch);
+  const isClickable = hasGame && isMyMatch;
   const isPlayable = hasGame && !isComplete && !isPending && isMyMatch;
   const isNotStarted = isPending || isScheduled;
 
@@ -212,7 +212,7 @@ function MatchCard({
             Live
           </span>
         )}
-        {isComplete && hasGame && (
+        {isComplete && hasGame && isMyMatch && (
           <span className="shrink-0 text-[10px] text-pong-text/30">view ↗</span>
         )}
         {isPlayable && (


### PR DESCRIPTION
## Summary

This PR fixes tournament bracket navigation for finished matches.

Previously, completed tournament match cards were clickable for any user, including non-participants.
That allowed eliminated players or other tournament participants to open `/game/:id`, which then led to an unauthorized / broken game screen.

This PR applies the simplest policy:
- only match participants can open a tournament match card
- completed matches are no longer clickable for non-participants
- `view ↗` is only shown to participants

This keeps the bracket accessible while avoiding broken navigation.

## Changes

- updated `BracketView` clickability rules
- restricted finished match navigation to participants only
- hid `view ↗` for non-participants
- updated unit tests accordingly

## Why

This aligns with the chosen no-spectator policy for now and prevents UI from exposing a route the user cannot actually access.

## Testing

Tested the following cases:
- participant can still open their finished match
- non-participant cannot open a finished match
- pending / non-playable cards remain non-clickable

## Issue

Closes #315