### PR TITLE
fix(tournament): show progression notifications on game page (#316)

### DIFF
--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -13,6 +13,7 @@ import { findWinningLine } from "../utils/gameUtils";
 
 import { gameReducer, initialGameState } from "./game/state";
 import { useGameSocketController } from "./game/useGameSocketController";
+import { useTournamentSocket } from "../hooks/useTournamentSocket";
 
 export default function Game() {
   const navigate = useNavigate();
@@ -35,6 +36,10 @@ export default function Game() {
     navigate,
     dispatch,
     stateRef,
+  });
+
+  useTournamentSocket({
+    socket: gameState.isTournament ? socket : null,
   });
 
   // Emit leave_game_room on tab close / refresh so the server cleans up


### PR DESCRIPTION
## Summary

This PR fixes missing tournament progression notifications while a player remains on `/game/:id`.

Previously, tournament socket listeners were mounted on tournament pages, but not on the game page.
As a result, players who stayed on the game screen after a match ended could miss:
- match completion notifications
- elimination notifications
- tournament completion notifications

This PR reuses the existing tournament socket hook directly in `Game.tsx`.

## Changes

- mounted `useTournamentSocket` in `Game.tsx`
- only enabled tournament listeners when the current game is a tournament game
- added / updated tests for tournament notifications while staying on the game page

## Why

This is the smallest possible fix:
- no new backend logic
- no duplicated event handling
- no new toast system
- just reuse the existing tournament notification flow on `/game/:id`

## Testing

Tested the following cases:
- player on `/game/:id` receives `tournament_match_completed`
- player on `/game/:id` receives `tournament_eliminated`
- player on `/game/:id` receives `tournament_completed`

## Issue

Closes #316